### PR TITLE
Allow upload on Amazon S3

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,11 @@ Example
     8> s3filez:delete(Cfg, <<"https://s.greenqloud.com/youraccount-default/Documents/LICENSE">>).
     ok
 
+Or, on Amazon S3:
+
+    6> s3filez:put(Cfg, <<"https://your-bucket.s3-eu-west-1.amazonaws.com/LICENSE">>, {filename, 10175, "LICENSE"}).
+
+
 Request Queue
 -------------
 


### PR DESCRIPTION
Fixes #2 

Amazon requires the bucket name as part of the resource path in the signature string.