### PR TITLE
Add API v4 support. Fixes #22

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        otp_version: [25,26,27]
+        otp_version: [26,27,28]
         os: [ubuntu-latest]
 
     container:

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -36,7 +36,7 @@ xref: $(REBAR)
 	$(REBAR) xref
 
 test: $(REBAR)
-	$(REBAR) $(REBAR_OPTS) ct
+	$(REBAR) $(REBAR_OPTS) eunit
 
 edoc: $(REBAR)
 	$(REBAR) edoc

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Distinction with other s3 clients is:
  * get with optional streaming function, to be able to stream to the filezcache
  * simple jobs queue, using the 'jobs' scheduler
 
-Example
--------
+Example (Signature V2 default)
+------------------------------
 
 ```erlang
 rebar3 shell
@@ -42,6 +42,25 @@ ok
 ok
 ```
 
+Signature V4 example
+--------------------
+
+```erlang
+1> application:ensure_all_started(s3filez).
+{ok,[jobs,s3filez]}
+2> Cfg = #{
+       username => <<"your-aws-key">>,
+       password => <<"your-aws-secret">>,
+       signature_version => v4,
+       region => <<"eu-west-1">>
+   }.
+#{region => <<"eu-west-1">>,signature_version => v4,username => <<"your-aws-key">>,password => <<"your-aws-secret">>}
+3> s3filez:get(Cfg, <<"https://your-bucket.s3-eu-west-1.amazonaws.com/LICENSE">>).
+{ok,<<"binary/octet-stream">>,_}
+```
+
+Signature V2 is the default if `signature_version` is not set.
+
 Request Queue
 -------------
 
@@ -62,4 +81,3 @@ The returned `JobPid` is the pid of the process in the s3filez queue supervisor.
 The callback can be a function (arity 2), `{M,F,A}` or a pid.
 
 If the callback is a pid then it will receive the message `{s3filez_done, ReqId, Result}`.
-

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Signature V4 example
 ```
 
 Signature V2 is the default if `signature_version` is not set.
+When using Signature V4, `region` must be set; otherwise calls return `{error, region_needed}`.
 
 Request Queue
 -------------

--- a/src/s3filez.erl
+++ b/src/s3filez.erl
@@ -86,7 +86,7 @@
 
 -type queue_reply() :: {ok, any(), pid()} | {error, {already_started, pid()}}.
 
--type sync_reply() :: ok | {error, enoent | forbidden | http_code()}.
+-type sync_reply() :: ok | {error, enoent | forbidden | http_code() | region_needed}.
 -type http_code() :: 100..600.
 
 -type put_opts() :: [ put_opt() ].
@@ -169,7 +169,7 @@ queue_stream_id(JobId, Config, Url, StreamFun) ->
 %% @doc Fetch the data at the url.
 -spec get( config(), url() ) ->
       {ok, ContentType::binary(), Data::binary()}
-    | {error, enoent | forbidden | http_code()}.
+    | {error, enoent | forbidden | http_code() | region_needed}.
 get(Config, Url) ->
     Result = jobs:run(s3filez_jobs, fun() -> request(Config, get, Url, [], []) end),
     case Result of
@@ -360,7 +360,7 @@ request(#{ username := Key } = Config, Method, Url, Headers, Options) ->
             Date = httpd_util:rfc1123_date(),
             Signature = sign(Config, Method, "", "", Date, Headers, Host, Path),
             AllHeaders = [
-                {"Authorization", lists:flatten(["AWS ",binary_to_list(Key),":",binary_to_list(Signature)])},
+                {"Authorization", lists:flatten(["AWS ",to_list(Key),":",binary_to_list(Signature)])},
                 {"Date", Date} | Headers
             ],
             httpc:request(Method, {binary_to_list(Url), AllHeaders},
@@ -379,7 +379,7 @@ request_with_body(#{ username := Key } = Config, Method, Url, Headers, Body) ->
             Date = httpd_util:rfc1123_date(),
             Signature = sign(Config, Method, ContentMD5, ContentType, Date, Headers, Host, Path),
             Hs1 = [
-                {"Authorization", lists:flatten(["AWS ",binary_to_list(Key),":",binary_to_list(Signature)])},
+                {"Authorization", lists:flatten(["AWS ",to_list(Key),":",binary_to_list(Signature)])},
                 {"Date", Date}
                 | Headers
             ],

--- a/src/s3filez.erl
+++ b/src/s3filez.erl
@@ -54,16 +54,6 @@
 
 -include_lib("kernel/include/logger.hrl").
 
--ifdef(TEST).
--export([
-    v4_required_config/1,
-    canonical_headers/1,
-    canonical_query_string/1,
-    v4_string_to_sign/4,
-    v4_signature/3,
-    v4_authorization/4
-]).
--endif.
 
 -define(BLOCK_SIZE, 65536).
 -define(CONNECT_TIMEOUT, 60000).    % 60s
@@ -488,25 +478,11 @@ signature_version(Config) ->
     maps:get(signature_version, Config, v2).
 
 request_v4(Config, Method, Url, Host, Path, Query, Headers, Options) ->
-    case v4_required_config(Config) of
+    case s3filez_sigv4:required_config(Config) of
         ok ->
-            AmzDate = amz_date(),
-            DateStamp = lists:sublist(AmzDate, 8),
-            PayloadHash = sha256_hex(<<>>),
-            AllHeaders = v4_headers(Host, AmzDate, PayloadHash, Headers, Config),
-            {CanonicalHeaders, SignedHeaders} = canonical_headers(AllHeaders),
-            CanonicalQuery = canonical_query_string(Query),
-            CanonicalRequest = iolist_to_binary([
-                method_string(Method), $\n,
-                canonical_uri(Path), $\n,
-                CanonicalQuery, $\n,
-                CanonicalHeaders, $\n,
-                SignedHeaders, $\n,
-                PayloadHash
-            ]),
-            StringToSign = v4_string_to_sign(Config, AmzDate, DateStamp, CanonicalRequest),
-            Signature = v4_signature(Config, DateStamp, StringToSign),
-            Authorization = v4_authorization(Config, DateStamp, SignedHeaders, Signature),
+            PayloadHash = s3filez_sigv4:payload_hash(<<>>),
+            {Authorization, AllHeaders} =
+                s3filez_sigv4:build_request(Config, Method, Host, Path, Query, Headers, PayloadHash),
             FinalHeaders = [
                 {"Authorization", Authorization}
                 | AllHeaders
@@ -519,26 +495,12 @@ request_v4(Config, Method, Url, Host, Path, Query, Headers, Options) ->
     end.
 
 request_with_body_v4(Config, Method, Url, Host, Path, Query, Headers, Body) ->
-    case v4_required_config(Config) of
+    case s3filez_sigv4:required_config(Config) of
         ok ->
             {"Content-Type", ContentType} = proplists:lookup("Content-Type", Headers),
-            PayloadHash = v4_payload_hash(Body),
-            AmzDate = amz_date(),
-            DateStamp = lists:sublist(AmzDate, 8),
-            AllHeaders = v4_headers(Host, AmzDate, PayloadHash, Headers, Config),
-            {CanonicalHeaders, SignedHeaders} = canonical_headers(AllHeaders),
-            CanonicalQuery = canonical_query_string(Query),
-            CanonicalRequest = iolist_to_binary([
-                method_string(Method), $\n,
-                canonical_uri(Path), $\n,
-                CanonicalQuery, $\n,
-                CanonicalHeaders, $\n,
-                SignedHeaders, $\n,
-                PayloadHash
-            ]),
-            StringToSign = v4_string_to_sign(Config, AmzDate, DateStamp, CanonicalRequest),
-            Signature = v4_signature(Config, DateStamp, StringToSign),
-            Authorization = v4_authorization(Config, DateStamp, SignedHeaders, Signature),
+            PayloadHash = s3filez_sigv4:payload_hash(Body),
+            {Authorization, AllHeaders} =
+                s3filez_sigv4:build_request(Config, Method, Host, Path, Query, Headers, PayloadHash),
             Hs1 = [
                 {"Authorization", Authorization}
                 | AllHeaders
@@ -552,157 +514,3 @@ request_with_body_v4(Config, Method, Url, Host, Path, Query, Headers, Body) ->
         {error, _} = Error ->
             Error
     end.
-
-v4_required_config(Config) ->
-    case maps:get(region, Config, undefined) of
-        undefined -> {error, region_needed};
-        _ -> ok
-    end.
-
-amz_date() ->
-    {{Y,M,D},{H,Mi,S}} = calendar:universal_time(),
-    lists:flatten(io_lib:format("~4..0B~2..0B~2..0BT~2..0B~2..0B~2..0BZ", [Y,M,D,H,Mi,S])).
-
-v4_headers(Host, AmzDate, PayloadHash, Headers, Config) ->
-    Base = [
-        {"Host", to_list(Host)},
-        {"x-amz-date", AmzDate},
-        {"x-amz-content-sha256", PayloadHash}
-        | Headers
-    ],
-    case maps:get(session_token, Config, undefined) of
-        undefined -> Base;
-        Token -> [{"x-amz-security-token", to_list(Token)} | Base]
-    end.
-
-canonical_headers(Headers) ->
-    Normalized = [ normalize_header(H, V) || {H, V} <- Headers ],
-    Combined = combine_headers(Normalized),
-    Sorted = lists:sort(Combined),
-    Canonical = [
-        [Name, $:, Value, $\n]
-        || {Name, Value} <- Sorted
-    ],
-    Signed = string:join([Name || {Name, _} <- Sorted], ";"),
-    {iolist_to_binary(Canonical), Signed}.
-
-normalize_header(H, V) ->
-    Name = string:lowercase(to_list(H)),
-    Value = normalize_header_value(to_list(V)),
-    {Name, Value}.
-
-normalize_header_value(Value) ->
-    Trimmed = string:trim(Value),
-    re:replace(Trimmed, "\\s+", " ", [global, {return, list}]).
-
-combine_headers(Headers) ->
-    lists:foldl(
-      fun({Name, Value}, Acc) ->
-              case lists:keyfind(Name, 1, Acc) of
-                  {Name, Existing} ->
-                      lists:keyreplace(Name, 1, Acc, {Name, Existing ++ "," ++ Value});
-                  false ->
-                      [{Name, Value} | Acc]
-              end
-      end, [], Headers).
-
-canonical_query_string(<<>>) ->
-    "";
-canonical_query_string(Query) ->
-    Parts = binary:split(Query, <<"&">>, [global]),
-    Pairs = [
-        case binary:split(P, <<"=">>) of
-            [K, V] -> {uri_encode(K), uri_encode(V)};
-            [K] -> {uri_encode(K), <<>>}
-        end
-        || P <- Parts, P =/= <<>>
-    ],
-    Sorted = lists:sort(Pairs),
-    Joined = lists:flatten(
-        string:join(
-            [binary_to_list(K) ++ "=" ++ binary_to_list(V) || {K, V} <- Sorted],
-            "&"
-        )
-    ),
-    Joined.
-
-canonical_uri(Path) ->
-    uri_encode_path(Path).
-
-uri_encode_path(Path) ->
-    %% Preserve '/' in paths, encode other bytes
-    Parts = binary:split(Path, <<"/">>, [global]),
-    Encoded = [uri_encode(P) || P <- Parts],
-    iolist_to_binary(string:join([binary_to_list(P) || P <- Encoded], "/")).
-
-uri_encode(Bin) when is_binary(Bin) ->
-    uri_encode(binary_to_list(Bin));
-uri_encode(List) when is_list(List) ->
-    iolist_to_binary([encode_byte(C) || C <- List]).
-
-encode_byte(C) when
-        (C >= $A andalso C =< $Z) orelse
-        (C >= $a andalso C =< $z) orelse
-        (C >= $0 andalso C =< $9) orelse
-        C =:= $-; C =:= $_; C =:= $.; C =:= $~ ->
-    [C];
-encode_byte(C) ->
-    io_lib:format("%~2.16.0B", [C]).
-
-v4_payload_hash(Body) when is_binary(Body) ->
-    sha256_hex(Body);
-v4_payload_hash({Fun, {file, Filename}}) when is_function(Fun, 1) ->
-    bin_to_hex(checksum_sha256(Filename));
-v4_payload_hash(_Body) ->
-    "UNSIGNED-PAYLOAD".
-
-sha256_hex(Bin) ->
-    bin_to_hex(crypto:hash(sha256, Bin)).
-
-bin_to_hex(Bin) ->
-    lists:flatten([io_lib:format("~2.16.0b", [B]) || <<B>> <= Bin]).
-
-checksum_sha256(Filename) ->
-    Ctx = crypto:hash_init(sha256),
-    {ok, FD} = file:open(Filename, [read,binary]),
-    Ctx1 = checksum_sha256_1(Ctx, FD),
-    file:close(FD),
-    crypto:hash_final(Ctx1).
-
-checksum_sha256_1(Ctx, FD) ->
-    case file:read(FD, ?BLOCK_SIZE) of
-        eof ->
-            Ctx;
-        {ok, Data} ->
-            checksum_sha256_1(crypto:hash_update(Ctx, Data), FD)
-    end.
-
-v4_string_to_sign(Config, AmzDate, DateStamp, CanonicalRequest) ->
-    Region = to_list(maps:get(region, Config)),
-    Scope = string:join([DateStamp, Region, "s3", "aws4_request"], "/"),
-    CanonicalHash = bin_to_hex(crypto:hash(sha256, CanonicalRequest)),
-    iolist_to_binary([
-        "AWS4-HMAC-SHA256\n",
-        AmzDate, "\n",
-        Scope, "\n",
-        CanonicalHash
-    ]).
-
-v4_signature(Config, DateStamp, StringToSign) ->
-    Region = to_list(maps:get(region, Config)),
-    Secret = to_list(maps:get(password, Config)),
-    KDate = crypto:mac(hmac, sha256, "AWS4" ++ Secret, DateStamp),
-    KRegion = crypto:mac(hmac, sha256, KDate, Region),
-    KService = crypto:mac(hmac, sha256, KRegion, "s3"),
-    KSigning = crypto:mac(hmac, sha256, KService, "aws4_request"),
-    bin_to_hex(crypto:mac(hmac, sha256, KSigning, StringToSign)).
-
-v4_authorization(Config, DateStamp, SignedHeaders, Signature) ->
-    Key = to_list(maps:get(username, Config)),
-    Region = to_list(maps:get(region, Config)),
-    Scope = string:join([DateStamp, Region, "s3", "aws4_request"], "/"),
-    lists:flatten([
-        "AWS4-HMAC-SHA256 Credential=", Key, "/", Scope,
-        ",SignedHeaders=", SignedHeaders,
-        ",Signature=", Signature
-    ]).

--- a/src/s3filez.erl
+++ b/src/s3filez.erl
@@ -433,7 +433,7 @@ canonicalize_amz_headers(Headers) ->
 ct(Headers) ->
     list_to_binary(proplists:get_value("content-type", Headers, "binary/octet-stream")).
 
--spec checksum(file:filename()) -> binary().
+-spec checksum(file:filename_all()) -> binary().
 checksum(Filename) ->
     Ctx = crypto:hash_init(md5),
     {ok, FD} = file:open(Filename, [read,binary]),

--- a/src/s3filez.erl
+++ b/src/s3filez.erl
@@ -1,10 +1,10 @@
 %% @author Marc Worrell
-%% @copyright 2013-2025 Marc Worrell
+%% @copyright 2013-2026 Marc Worrell
 %% @doc S3 file storage. Can put, get and stream files from S3 compatible services.
 %% Uses a job queue which is regulated by "jobs".
 %% @end
 
-%% Copyright 2013-2025 Marc Worrell
+%% Copyright 2013-2026 Marc Worrell
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -54,6 +54,17 @@
 
 -include_lib("kernel/include/logger.hrl").
 
+-ifdef(TEST).
+-export([
+    v4_required_config/1,
+    canonical_headers/1,
+    canonical_query_string/1,
+    v4_string_to_sign/4,
+    v4_signature/3,
+    v4_authorization/4
+]).
+-endif.
+
 -define(BLOCK_SIZE, 65536).
 -define(CONNECT_TIMEOUT, 60000).    % 60s
 -define(TIMEOUT, 1800000).          % 30m
@@ -61,7 +72,10 @@
 -type config() :: #{
         username := binary() | string(),
         password := binary() | string(),
-        tls_options => list()
+        tls_options => list(),
+        signature_version => v2 | v4,
+        region => binary() | string(),
+        session_token => binary() | string()
     }.
 -type url() :: binary().
 -type ready_fun() :: undefined | {atom(),atom(),list()} | fun() | pid().
@@ -338,34 +352,44 @@ http_status({{_,Code,_}, _Headers, _Body}) ->
 
 
 request(#{ username := Key } = Config, Method, Url, Headers, Options) ->
-    {_Scheme, Host, Path} = urlsplit(Url),
-    Date = httpd_util:rfc1123_date(),
-    Signature = sign(Config, Method, "", "", Date, Headers, Host, Path),
-    AllHeaders = [
-        {"Authorization", lists:flatten(["AWS ",binary_to_list(Key),":",binary_to_list(Signature)])},
-        {"Date", Date} | Headers
-    ],
-    httpc:request(Method, {binary_to_list(Url), AllHeaders},
-                  opts(Host, Config), [{body_format, binary}|Options],
-                  httpc_s3filez_profile).
+    {_Scheme, Host, Path, Query} = urlsplit(Url),
+    case signature_version(Config) of
+        v4 ->
+            request_v4(Config, Method, Url, Host, Path, Query, Headers, Options);
+        v2 ->
+            Date = httpd_util:rfc1123_date(),
+            Signature = sign(Config, Method, "", "", Date, Headers, Host, Path),
+            AllHeaders = [
+                {"Authorization", lists:flatten(["AWS ",binary_to_list(Key),":",binary_to_list(Signature)])},
+                {"Date", Date} | Headers
+            ],
+            httpc:request(Method, {binary_to_list(Url), AllHeaders},
+                          opts(Host, Config), [{body_format, binary}|Options],
+                          httpc_s3filez_profile)
+    end.
 
 request_with_body(#{ username := Key } = Config, Method, Url, Headers, Body) ->
-    {_Scheme, Host, Path} = urlsplit(Url),
-    {"Content-Type", ContentType} = proplists:lookup("Content-Type", Headers),
-    {"Content-MD5", ContentMD5} = proplists:lookup("Content-MD5", Headers),
-    Date = httpd_util:rfc1123_date(),
-    Signature = sign(Config, Method, ContentMD5, ContentType, Date, Headers, Host, Path),
-    Hs1 = [
-        {"Authorization", lists:flatten(["AWS ",binary_to_list(Key),":",binary_to_list(Signature)])},
-        {"Date", Date}
-        | Headers
-    ],
-    jobs:run(s3filez_jobs,
-             fun() ->
-                httpc:request(Method, {binary_to_list(Url), Hs1, ContentType, Body},
-                              opts(Host, Config), [],
-                              httpc_s3filez_profile)
-            end).
+    {_Scheme, Host, Path, Query} = urlsplit(Url),
+    case signature_version(Config) of
+        v4 ->
+            request_with_body_v4(Config, Method, Url, Host, Path, Query, Headers, Body);
+        v2 ->
+            {"Content-Type", ContentType} = proplists:lookup("Content-Type", Headers),
+            {"Content-MD5", ContentMD5} = proplists:lookup("Content-MD5", Headers),
+            Date = httpd_util:rfc1123_date(),
+            Signature = sign(Config, Method, ContentMD5, ContentType, Date, Headers, Host, Path),
+            Hs1 = [
+                {"Authorization", lists:flatten(["AWS ",binary_to_list(Key),":",binary_to_list(Signature)])},
+                {"Date", Date}
+                | Headers
+            ],
+            jobs:run(s3filez_jobs,
+                     fun() ->
+                        httpc:request(Method, {binary_to_list(Url), Hs1, ContentType, Body},
+                                      opts(Host, Config), [],
+                                      httpc_s3filez_profile)
+                    end)
+    end.
 
 
 opts(Host, Config) ->
@@ -439,23 +463,246 @@ checksum1(Ctx, FD) ->
 urlsplit(Url) ->
     case binary:split(Url, <<":">>) of
         [Scheme, <<"//", HostPath/binary>>] ->
-            {Host,Path} = urlsplit_hostpath(HostPath),
-            {Scheme, Host, Path};
+            {Host,Path,Query} = urlsplit_hostpath(HostPath),
+            {Scheme, Host, Path, Query};
         [<<"//", HostPath/binary>>] ->
-            {Host,Path} = urlsplit_hostpath(HostPath),
-            {no_scheme, Host, Path};
+            {Host,Path,Query} = urlsplit_hostpath(HostPath),
+            {no_scheme, Host, Path, Query};
         [Path] ->
-            {no_scheme, <<>>, Path}
+            {no_scheme, <<>>, Path, <<>>}
     end.
 
 urlsplit_hostpath(HP) ->
     case binary:split(HP, <<"/">>) of
-        [Host,Path] -> {Host,urlsplit_path(binary:split(Path, <<"?">>))};
-        [Host] -> {Host, <<"/">>}
+        [Host,Path] -> {Path1,Query} = urlsplit_path(binary:split(Path, <<"?">>)), {Host, Path1, Query};
+        [Host] -> {Host, <<"/">>, <<>>}
     end.
 
-urlsplit_path([Path]) -> <<"/", Path/binary>>;
-urlsplit_path([Path, _]) -> <<"/", Path/binary>>.
+urlsplit_path([Path]) -> {<<"/", Path/binary>>, <<>>};
+urlsplit_path([Path, Query]) -> {<<"/", Path/binary>>, Query}.
 
 to_list(B) when is_binary(B) -> binary_to_list(B);
 to_list(L) when is_list(L) -> L.
+
+signature_version(Config) ->
+    maps:get(signature_version, Config, v2).
+
+request_v4(Config, Method, Url, Host, Path, Query, Headers, Options) ->
+    case v4_required_config(Config) of
+        ok ->
+            AmzDate = amz_date(),
+            DateStamp = lists:sublist(AmzDate, 8),
+            PayloadHash = sha256_hex(<<>>),
+            AllHeaders = v4_headers(Host, AmzDate, PayloadHash, Headers, Config),
+            {CanonicalHeaders, SignedHeaders} = canonical_headers(AllHeaders),
+            CanonicalQuery = canonical_query_string(Query),
+            CanonicalRequest = iolist_to_binary([
+                method_string(Method), $\n,
+                canonical_uri(Path), $\n,
+                CanonicalQuery, $\n,
+                CanonicalHeaders, $\n,
+                SignedHeaders, $\n,
+                PayloadHash
+            ]),
+            StringToSign = v4_string_to_sign(Config, AmzDate, DateStamp, CanonicalRequest),
+            Signature = v4_signature(Config, DateStamp, StringToSign),
+            Authorization = v4_authorization(Config, DateStamp, SignedHeaders, Signature),
+            FinalHeaders = [
+                {"Authorization", Authorization}
+                | AllHeaders
+            ],
+            httpc:request(Method, {binary_to_list(Url), FinalHeaders},
+                          opts(Host, Config), [{body_format, binary}|Options],
+                          httpc_s3filez_profile);
+        {error, _} = Error ->
+            Error
+    end.
+
+request_with_body_v4(Config, Method, Url, Host, Path, Query, Headers, Body) ->
+    case v4_required_config(Config) of
+        ok ->
+            {"Content-Type", ContentType} = proplists:lookup("Content-Type", Headers),
+            PayloadHash = v4_payload_hash(Body),
+            AmzDate = amz_date(),
+            DateStamp = lists:sublist(AmzDate, 8),
+            AllHeaders = v4_headers(Host, AmzDate, PayloadHash, Headers, Config),
+            {CanonicalHeaders, SignedHeaders} = canonical_headers(AllHeaders),
+            CanonicalQuery = canonical_query_string(Query),
+            CanonicalRequest = iolist_to_binary([
+                method_string(Method), $\n,
+                canonical_uri(Path), $\n,
+                CanonicalQuery, $\n,
+                CanonicalHeaders, $\n,
+                SignedHeaders, $\n,
+                PayloadHash
+            ]),
+            StringToSign = v4_string_to_sign(Config, AmzDate, DateStamp, CanonicalRequest),
+            Signature = v4_signature(Config, DateStamp, StringToSign),
+            Authorization = v4_authorization(Config, DateStamp, SignedHeaders, Signature),
+            Hs1 = [
+                {"Authorization", Authorization}
+                | AllHeaders
+            ],
+            jobs:run(s3filez_jobs,
+                     fun() ->
+                        httpc:request(Method, {binary_to_list(Url), Hs1, ContentType, Body},
+                                      opts(Host, Config), [],
+                                      httpc_s3filez_profile)
+                    end);
+        {error, _} = Error ->
+            Error
+    end.
+
+v4_required_config(Config) ->
+    case maps:get(region, Config, undefined) of
+        undefined -> {error, region_needed};
+        _ -> ok
+    end.
+
+amz_date() ->
+    {{Y,M,D},{H,Mi,S}} = calendar:universal_time(),
+    lists:flatten(io_lib:format("~4..0B~2..0B~2..0BT~2..0B~2..0B~2..0BZ", [Y,M,D,H,Mi,S])).
+
+v4_headers(Host, AmzDate, PayloadHash, Headers, Config) ->
+    Base = [
+        {"Host", to_list(Host)},
+        {"x-amz-date", AmzDate},
+        {"x-amz-content-sha256", PayloadHash}
+        | Headers
+    ],
+    case maps:get(session_token, Config, undefined) of
+        undefined -> Base;
+        Token -> [{"x-amz-security-token", to_list(Token)} | Base]
+    end.
+
+canonical_headers(Headers) ->
+    Normalized = [ normalize_header(H, V) || {H, V} <- Headers ],
+    Combined = combine_headers(Normalized),
+    Sorted = lists:sort(Combined),
+    Canonical = [
+        [Name, $:, Value, $\n]
+        || {Name, Value} <- Sorted
+    ],
+    Signed = string:join([Name || {Name, _} <- Sorted], ";"),
+    {iolist_to_binary(Canonical), Signed}.
+
+normalize_header(H, V) ->
+    Name = string:lowercase(to_list(H)),
+    Value = normalize_header_value(to_list(V)),
+    {Name, Value}.
+
+normalize_header_value(Value) ->
+    Trimmed = string:trim(Value),
+    re:replace(Trimmed, "\\s+", " ", [global, {return, list}]).
+
+combine_headers(Headers) ->
+    lists:foldl(
+      fun({Name, Value}, Acc) ->
+              case lists:keyfind(Name, 1, Acc) of
+                  {Name, Existing} ->
+                      lists:keyreplace(Name, 1, Acc, {Name, Existing ++ "," ++ Value});
+                  false ->
+                      [{Name, Value} | Acc]
+              end
+      end, [], Headers).
+
+canonical_query_string(<<>>) ->
+    "";
+canonical_query_string(Query) ->
+    Parts = binary:split(Query, <<"&">>, [global]),
+    Pairs = [
+        case binary:split(P, <<"=">>) of
+            [K, V] -> {uri_encode(K), uri_encode(V)};
+            [K] -> {uri_encode(K), <<>>}
+        end
+        || P <- Parts, P =/= <<>>
+    ],
+    Sorted = lists:sort(Pairs),
+    Joined = lists:flatten(
+        string:join(
+            [binary_to_list(K) ++ "=" ++ binary_to_list(V) || {K, V} <- Sorted],
+            "&"
+        )
+    ),
+    Joined.
+
+canonical_uri(Path) ->
+    uri_encode_path(Path).
+
+uri_encode_path(Path) ->
+    %% Preserve '/' in paths, encode other bytes
+    Parts = binary:split(Path, <<"/">>, [global]),
+    Encoded = [uri_encode(P) || P <- Parts],
+    iolist_to_binary(string:join([binary_to_list(P) || P <- Encoded], "/")).
+
+uri_encode(Bin) when is_binary(Bin) ->
+    uri_encode(binary_to_list(Bin));
+uri_encode(List) when is_list(List) ->
+    iolist_to_binary([encode_byte(C) || C <- List]).
+
+encode_byte(C) when
+        (C >= $A andalso C =< $Z) orelse
+        (C >= $a andalso C =< $z) orelse
+        (C >= $0 andalso C =< $9) orelse
+        C =:= $-; C =:= $_; C =:= $.; C =:= $~ ->
+    [C];
+encode_byte(C) ->
+    io_lib:format("%~2.16.0B", [C]).
+
+v4_payload_hash(Body) when is_binary(Body) ->
+    sha256_hex(Body);
+v4_payload_hash({Fun, {file, Filename}}) when is_function(Fun, 1) ->
+    bin_to_hex(checksum_sha256(Filename));
+v4_payload_hash(_Body) ->
+    "UNSIGNED-PAYLOAD".
+
+sha256_hex(Bin) ->
+    bin_to_hex(crypto:hash(sha256, Bin)).
+
+bin_to_hex(Bin) ->
+    lists:flatten([io_lib:format("~2.16.0b", [B]) || <<B>> <= Bin]).
+
+checksum_sha256(Filename) ->
+    Ctx = crypto:hash_init(sha256),
+    {ok, FD} = file:open(Filename, [read,binary]),
+    Ctx1 = checksum_sha256_1(Ctx, FD),
+    file:close(FD),
+    crypto:hash_final(Ctx1).
+
+checksum_sha256_1(Ctx, FD) ->
+    case file:read(FD, ?BLOCK_SIZE) of
+        eof ->
+            Ctx;
+        {ok, Data} ->
+            checksum_sha256_1(crypto:hash_update(Ctx, Data), FD)
+    end.
+
+v4_string_to_sign(Config, AmzDate, DateStamp, CanonicalRequest) ->
+    Region = to_list(maps:get(region, Config)),
+    Scope = string:join([DateStamp, Region, "s3", "aws4_request"], "/"),
+    CanonicalHash = bin_to_hex(crypto:hash(sha256, CanonicalRequest)),
+    iolist_to_binary([
+        "AWS4-HMAC-SHA256\n",
+        AmzDate, "\n",
+        Scope, "\n",
+        CanonicalHash
+    ]).
+
+v4_signature(Config, DateStamp, StringToSign) ->
+    Region = to_list(maps:get(region, Config)),
+    Secret = to_list(maps:get(password, Config)),
+    KDate = crypto:mac(hmac, sha256, "AWS4" ++ Secret, DateStamp),
+    KRegion = crypto:mac(hmac, sha256, KDate, Region),
+    KService = crypto:mac(hmac, sha256, KRegion, "s3"),
+    KSigning = crypto:mac(hmac, sha256, KService, "aws4_request"),
+    bin_to_hex(crypto:mac(hmac, sha256, KSigning, StringToSign)).
+
+v4_authorization(Config, DateStamp, SignedHeaders, Signature) ->
+    Key = to_list(maps:get(username, Config)),
+    Region = to_list(maps:get(region, Config)),
+    Scope = string:join([DateStamp, Region, "s3", "aws4_request"], "/"),
+    lists:flatten([
+        "AWS4-HMAC-SHA256 Credential=", Key, "/", Scope,
+        ",SignedHeaders=", SignedHeaders,
+        ",Signature=", Signature
+    ]).

--- a/src/s3filez.erl
+++ b/src/s3filez.erl
@@ -203,6 +203,8 @@ put(Config, Url, {filename, Size, Filename}, Opts) ->
     ],
     ret_status(request_with_body(Config, put, Url, Hs, {fun ?MODULE:put_body_file/1, {file, Filename}})).
 
+-spec put_body_file({file, file:filename_all()} | {fd, file:io_device()}) ->
+    eof | {ok, binary(), {fd, file:io_device()}}.
 put_body_file({file, Filename}) ->
     {ok, FD} = file:open(Filename, [read,binary]),
     put_body_file({fd, FD});
@@ -302,6 +304,7 @@ stream_to_fun(Config, Url, Fun) ->
     end.
 
 %% @private
+-spec stream_loop(reference(), pid(), url(), stream_fun()) -> ok | {error, term()}.
 stream_loop(RequestId, Pid, Url, Fun) ->
     receive
         {http, {RequestId, stream_end, Headers}} ->

--- a/src/s3filez.erl
+++ b/src/s3filez.erl
@@ -464,10 +464,28 @@ urlsplit(Url) ->
             undefined -> no_scheme;
             S -> list_to_binary(S)
         end,
-    Host =
+    Host0 =
         case maps:get(host, Parts, undefined) of
             undefined -> <<>>;
             H -> list_to_binary(H)
+        end,
+    Port = maps:get(port, Parts, undefined),
+    DefaultPort =
+        case Scheme of
+            <<"http">>  -> 80;
+            <<"https">> -> 443;
+            _           -> undefined
+        end,
+    Host =
+        case {Host0, Port} of
+            {<<>>, _} ->
+                <<>>;
+            {H, undefined} ->
+                H;
+            {H, P} when is_integer(P), P =:= DefaultPort ->
+                H;
+            {H, P} when is_integer(P) ->
+                <<H/binary, $:, (integer_to_binary(P))/binary>>
         end,
     Path0 = maps:get(path, Parts, []),
     Path =

--- a/src/s3filez_app.erl
+++ b/src/s3filez_app.erl
@@ -24,6 +24,7 @@
 
 -export([start/2, stop/1]).
 
+-spec start(application:start_type(), term()) -> {ok, pid()} | {error, term()}.
 start(_StartType, _StartArgs) ->
     ensure_httpc_profile(),
     case s3filez_sup:start_link() of
@@ -34,6 +35,7 @@ start(_StartType, _StartArgs) ->
             {error, Other}
     end.
 
+-spec stop(term()) -> ok.
 stop(_State) ->
     ok.
 

--- a/src/s3filez_app.erl
+++ b/src/s3filez_app.erl
@@ -4,7 +4,7 @@
 %% supervisor for the queued jobs.
 %% @end
 
-%% Copyright 2013-2025 Marc Worrell
+%% Copyright 2013-2026 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.

--- a/src/s3filez_job.erl
+++ b/src/s3filez_job.erl
@@ -32,26 +32,35 @@
 
 -record(state, {job_id, cmd}).
 
+-type state() :: #state{}.
+
+-spec start_link(term(), term()) -> {ok, pid()} | {error, term()}.
 start_link(JobId, Cmd) ->
     gen_server:start_link({via, gproc, {n,l,{s3filez_job,JobId}}}, ?MODULE, [JobId, Cmd], []).
 
+-spec init([term()]) -> {ok, state()}.
 init([JobId, Cmd]) ->
     gen_server:cast(self(), run),
     {ok, #state{job_id=JobId, cmd=Cmd}}.
 
+-spec handle_call(term(), {pid(), term()}, state()) -> {reply, term(), state()}.
 handle_call(Msg, _From, State) ->
     {reply, {unknown_msg, Msg}, State}.
 
+-spec handle_cast(term(), state()) -> {stop, normal, state()} | {noreply, state()}.
 handle_cast(run, #state{cmd=Cmd, job_id=JobId} = State) ->
     do_cmd(JobId, Cmd),
     {stop, normal, State}.
 
+-spec handle_info(term(), state()) -> {noreply, state()}.
 handle_info(_Info, State) ->
     {noreply, State}.
 
+-spec code_change(term(), state(), term()) -> {ok, state()}.
 code_change(_OldVersion, State, _Extra) ->
     {ok, State}.
 
+-spec terminate(term(), state()) -> ok.
 terminate(_Reason, _State) ->
     ok.
 
@@ -78,5 +87,4 @@ on_ready(_JobId, Result, Fun) when is_function(Fun,1) ->
     Fun(Result);
 on_ready(JobId, Result, Pid) when is_pid(Pid) ->
     Pid ! {s3filez_done, JobId, Result}.
-
 

--- a/src/s3filez_job.erl
+++ b/src/s3filez_job.erl
@@ -1,9 +1,9 @@
 %% @author Marc Worrell
-%% @copyright 2013-2025 Marc Worrell
+%% @copyright 2013-2026 Marc Worrell
 %% @doc Async queued job, scheduled by jobs and supervised by s3filez_sup.
 %% @end
 
-%% Copyright 2013-2025 Marc Worrell
+%% Copyright 2013-2026 Marc Worrell
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/s3filez_jobs_sup.erl
+++ b/src/s3filez_jobs_sup.erl
@@ -31,18 +31,22 @@
 %% Supervisor callbacks
 -export([init/1]).
 
+-spec queue(term()) -> {ok, reference(), pid()} | {error, term()}.
 queue(S3Job) ->
     queue(erlang:make_ref(), S3Job).
 
+-spec queue(reference(), term()) -> {ok, reference(), pid()} | {error, term()}.
 queue(Ref, S3Job) ->
     case supervisor:start_child(?MODULE, [Ref, S3Job]) of
         {ok, Pid} -> {ok, Ref, Pid};
         {error, {already_started, Pid}} -> {ok, Ref, Pid}
     end.
 
+-spec start_link() -> {ok, pid()} | {error, term()}.
 start_link() ->
     supervisor:start_link({local, ?MODULE}, ?MODULE, []).
 
+-spec init(term()) -> {ok, {supervisor:sup_flags(), [supervisor:child_spec()]}}.
 init([]) ->
     Worker = {s3filez_job, {s3filez_job, start_link, []},
               temporary, 10000, worker, [s3filez_job]},

--- a/src/s3filez_jobs_sup.erl
+++ b/src/s3filez_jobs_sup.erl
@@ -1,9 +1,9 @@
 %% @author Marc Worrell
-%% @copyright 2013-2025 Marc Worrell
+%% @copyright 2013-2026 Marc Worrell
 %% @doc Supervisor for all s3 async queued jobs.
 %% @end
 
-%% Copyright 2013-2025 Marc Worrell
+%% Copyright 2013-2026 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.

--- a/src/s3filez_sigv2.erl
+++ b/src/s3filez_sigv2.erl
@@ -1,0 +1,58 @@
+%% @author Marc Worrell
+%% @copyright 2013-2026 Marc Worrell
+%% @doc AWS Signature Version 2 helpers for s3filez.
+%% @end
+
+%% Copyright 2013-2026 Marc Worrell
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+
+-module(s3filez_sigv2).
+
+-export([
+    sign/8
+]).
+
+sign(#{ password := Secret }, Method, BodyMD5, ContentType, Date, Headers, Host, Path) ->
+    ResourcePrefix =
+        case lists:reverse(Split=binary:split(Host, <<".">>, [global])) of
+            [<<"com">>, <<"amazonaws">> | _] ->
+                ["/", hd(Split)];
+            _ ->
+                []
+        end,
+    Data = [
+            method_string(Method), $\n,
+            BodyMD5, $\n,
+            ContentType, $\n,
+            Date, $\n,
+            canonicalize_amz_headers(Headers),
+            iolist_to_binary([ResourcePrefix, Path])
+           ],
+    base64:encode(crypto:mac(hmac, sha, Secret, Data)).
+
+method_string('put') -> "PUT";
+method_string('get') -> "GET";
+method_string('delete') -> "DELETE".
+
+canonicalize_amz_headers(Headers) ->
+    AmzHeaders = lists:sort(lists:filter(fun({"x-amz-" ++ _, _}) -> true; (_) -> false end, Headers)),
+    [
+     [
+      H, $:, V, $\n
+     ]
+     || {H, V} <- AmzHeaders
+    ].

--- a/src/s3filez_sigv2.erl
+++ b/src/s3filez_sigv2.erl
@@ -26,6 +26,16 @@
     sign/8
 ]).
 
+-spec sign(
+    map(),
+    atom(),
+    iodata(),
+    iodata(),
+    iodata(),
+    list(),
+    binary(),
+    binary()
+) -> binary().
 sign(#{ password := Secret }, Method, BodyMD5, ContentType, Date, Headers, Host, Path) ->
     ResourcePrefix =
         case lists:reverse(Split=binary:split(Host, <<".">>, [global])) of

--- a/src/s3filez_sigv4.erl
+++ b/src/s3filez_sigv4.erl
@@ -1,0 +1,207 @@
+%% @author Marc Worrell
+%% @copyright 2026 Marc Worrell
+%% @doc AWS Signature Version 4 helpers for s3filez.
+%% @end
+
+%% Copyright 2013-2026 Marc Worrell
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+-module(s3filez_sigv4).
+
+-export([
+    required_config/1,
+    amz_date/0,
+    headers/5,
+    canonical_headers/1,
+    canonical_query_string/1,
+    canonical_uri/1,
+    payload_hash/1,
+    build_request/7,
+    string_to_sign/4,
+    signature/3,
+    authorization/4
+]).
+
+-define(BLOCK_SIZE, 65536).
+
+required_config(Config) ->
+    case maps:get(region, Config, undefined) of
+        undefined -> {error, region_needed};
+        _ -> ok
+    end.
+
+amz_date() ->
+    {{Y,M,D},{H,Mi,S}} = calendar:universal_time(),
+    lists:flatten(io_lib:format("~4..0B~2..0B~2..0BT~2..0B~2..0B~2..0BZ", [Y,M,D,H,Mi,S])).
+
+headers(Host, AmzDate, PayloadHash, Headers, Config) ->
+    Base = [
+        {"Host", to_list(Host)},
+        {"x-amz-date", AmzDate},
+        {"x-amz-content-sha256", PayloadHash}
+        | Headers
+    ],
+    case maps:get(session_token, Config, undefined) of
+        undefined -> Base;
+        Token -> [{"x-amz-security-token", to_list(Token)} | Base]
+    end.
+
+canonical_headers(Headers) ->
+    Normalized = [ normalize_header(H, V) || {H, V} <- Headers ],
+    Combined = combine_headers(Normalized),
+    Sorted = lists:sort(Combined),
+    Canonical = [
+        [Name, $:, Value, $\n]
+        || {Name, Value} <- Sorted
+    ],
+    Signed = string:join([Name || {Name, _} <- Sorted], ";"),
+    {iolist_to_binary(Canonical), Signed}.
+
+canonical_query_string(<<>>) ->
+    "";
+canonical_query_string(Query) ->
+    Parts = binary:split(Query, <<"&">>, [global]),
+    Pairs = [
+        case binary:split(P, <<"=">>) of
+            [K, V] -> {uri_encode(K), uri_encode(V)};
+            [K] -> {uri_encode(K), <<>>}
+        end
+        || P <- Parts, P =/= <<>>
+    ],
+    Sorted = lists:sort(Pairs),
+    Joined = lists:flatten(
+        string:join(
+            [binary_to_list(K) ++ "=" ++ binary_to_list(V) || {K, V} <- Sorted],
+            "&"
+        )
+    ),
+    Joined.
+
+canonical_uri(Path) ->
+    uri_encode_path(Path).
+
+build_request(Config, Method, Host, Path, Query, Headers, PayloadHash) ->
+    AmzDate = amz_date(),
+    DateStamp = lists:sublist(AmzDate, 8),
+    AllHeaders = headers(Host, AmzDate, PayloadHash, Headers, Config),
+    {CanonicalHeaders, SignedHeaders} = canonical_headers(AllHeaders),
+    CanonicalQuery = canonical_query_string(Query),
+    CanonicalRequest = iolist_to_binary([
+        method_string(Method), $\n,
+        canonical_uri(Path), $\n,
+        CanonicalQuery, $\n,
+        CanonicalHeaders, $\n,
+        SignedHeaders, $\n,
+        PayloadHash
+    ]),
+    StringToSign = string_to_sign(Config, AmzDate, DateStamp, CanonicalRequest),
+    Signature = signature(Config, DateStamp, StringToSign),
+    Authorization = authorization(Config, DateStamp, SignedHeaders, Signature),
+    {Authorization, AllHeaders}.
+
+payload_hash(Body) when is_binary(Body) ->
+    sha256_hex(Body);
+payload_hash({Fun, {file, Filename}}) when is_function(Fun, 1) ->
+    bin_to_hex(checksum_sha256(Filename));
+payload_hash(_Body) ->
+    "UNSIGNED-PAYLOAD".
+
+string_to_sign(Config, AmzDate, DateStamp, CanonicalRequest) ->
+    Region = to_list(maps:get(region, Config)),
+    Scope = string:join([DateStamp, Region, "s3", "aws4_request"], "/"),
+    CanonicalHash = bin_to_hex(crypto:hash(sha256, CanonicalRequest)),
+    iolist_to_binary([
+        "AWS4-HMAC-SHA256\n",
+        AmzDate, "\n",
+        Scope, "\n",
+        CanonicalHash
+    ]).
+
+signature(Config, DateStamp, StringToSign) ->
+    Region = to_list(maps:get(region, Config)),
+    Secret = to_list(maps:get(password, Config)),
+    KDate = crypto:mac(hmac, sha256, "AWS4" ++ Secret, DateStamp),
+    KRegion = crypto:mac(hmac, sha256, KDate, Region),
+    KService = crypto:mac(hmac, sha256, KRegion, "s3"),
+    KSigning = crypto:mac(hmac, sha256, KService, "aws4_request"),
+    bin_to_hex(crypto:mac(hmac, sha256, KSigning, StringToSign)).
+
+authorization(Config, DateStamp, SignedHeaders, Signature) ->
+    Key = to_list(maps:get(username, Config)),
+    Region = to_list(maps:get(region, Config)),
+    Scope = string:join([DateStamp, Region, "s3", "aws4_request"], "/"),
+    lists:flatten([
+        "AWS4-HMAC-SHA256 Credential=", Key, "/", Scope,
+        ",SignedHeaders=", SignedHeaders,
+        ",Signature=", Signature
+    ]).
+
+uri_encode_path(Path) ->
+    %% Preserve '/' in paths, encode other bytes
+    Parts = binary:split(Path, <<"/">>, [global]),
+    Encoded = [uri_encode(P) || P <- Parts],
+    iolist_to_binary(string:join([binary_to_list(P) || P <- Encoded], "/")).
+
+uri_encode(Bin) ->
+    z_url:percent_encode(Bin).
+
+normalize_header(H, V) ->
+    Name = string:lowercase(to_list(H)),
+    Value = normalize_header_value(to_list(V)),
+    {Name, Value}.
+
+normalize_header_value(Value) ->
+    Trimmed = string:trim(Value),
+    re:replace(Trimmed, "\\s+", " ", [global, {return, list}]).
+
+combine_headers(Headers) ->
+    lists:foldl(
+      fun({Name, Value}, Acc) ->
+              case lists:keyfind(Name, 1, Acc) of
+                  {Name, Existing} ->
+                      lists:keyreplace(Name, 1, Acc, {Name, Existing ++ "," ++ Value});
+                  false ->
+                      [{Name, Value} | Acc]
+              end
+      end, [], Headers).
+
+sha256_hex(Bin) ->
+    bin_to_hex(crypto:hash(sha256, Bin)).
+
+bin_to_hex(Bin) ->
+    lists:flatten([io_lib:format("~2.16.0b", [B]) || <<B>> <= Bin]).
+
+checksum_sha256(Filename) ->
+    Ctx = crypto:hash_init(sha256),
+    {ok, FD} = file:open(Filename, [read,binary]),
+    Ctx1 = checksum_sha256_1(Ctx, FD),
+    file:close(FD),
+    crypto:hash_final(Ctx1).
+
+checksum_sha256_1(Ctx, FD) ->
+    case file:read(FD, ?BLOCK_SIZE) of
+        eof ->
+            Ctx;
+        {ok, Data} ->
+            checksum_sha256_1(crypto:hash_update(Ctx, Data), FD)
+    end.
+
+to_list(B) when is_binary(B) -> binary_to_list(B);
+to_list(L) when is_list(L) -> L.
+
+method_string('put') -> "PUT";
+method_string('get') -> "GET";
+method_string('delete') -> "DELETE".

--- a/src/s3filez_sup.erl
+++ b/src/s3filez_sup.erl
@@ -27,13 +27,14 @@
 
 -define(SERVER, ?MODULE).
 
+-spec start_link() -> {ok, pid()} | {error, term()}.
 start_link() ->
     supervisor:start_link({local, ?SERVER}, ?MODULE, []).
 
+-spec init(term()) -> {ok, {supervisor:sup_flags(), [supervisor:child_spec()]}}.
 init([]) ->
     JobsSup = {s3filez_jobs_sup, {s3filez_jobs_sup, start_link, []},
                      permanent, 2000, supervisor, [s3filez_jobs_sup]},
     Children = [JobsSup],
     RestartStrategy = {one_for_one, 4, 3600},
     {ok, {RestartStrategy, Children}}.
-

--- a/src/s3filez_sup.erl
+++ b/src/s3filez_sup.erl
@@ -1,7 +1,7 @@
 %% @author Marc Worrell
-%% @copyright 2013-2025 Marc Worrell
+%% @copyright 2013-2026 Marc Worrell
 
-%% Copyright 2013-2025 Marc Worrell
+%% Copyright 2013-2026 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.

--- a/test/s3filez_e2e_test.erl
+++ b/test/s3filez_e2e_test.erl
@@ -1,0 +1,428 @@
+%% @author Marc Worrell
+%% @copyright 2013-2026 Marc Worrell
+%% @doc End-to-end tests using a minimal dummy S3 server.
+%% @end
+%%
+%% Copyright 2013-2026 Marc Worrell
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+
+-module(s3filez_e2e_test).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(READ_TIMEOUT, 5000).
+
+e2e_put_get_delete_test() ->
+    case start_server() of
+        {skip, Reason} ->
+            {skip, Reason};
+        {Pid, Port} ->
+    try
+        [ok = application:ensure_started(X) || X <- [crypto, public_key, ssl, ssl_verify_fun, inets, jobs, tls_certificate_check, s3filez]],
+        Cfg = #{
+            username => <<"test-access">>,
+            password => <<"test-secret">>
+        },
+        Url = list_to_binary(io_lib:format("http://127.0.0.1:~B/test-bucket/test-key", [Port])),
+        ok = s3filez:put(Cfg, Url, {data, <<"hello">>}),
+        {ok, <<"binary/octet-stream">>, <<"hello">>} = s3filez:get(Cfg, Url),
+        ok = s3filez:delete(Cfg, Url),
+        {error, enoent} = s3filez:get(Cfg, Url)
+    after
+        stop_server(Pid)
+    end
+    end.
+
+e2e_put_get_delete_v4_test() ->
+    case start_server() of
+        {skip, Reason} ->
+            {skip, Reason};
+        {Pid, Port} ->
+    try
+        [ok = application:ensure_started(X) || X <- [crypto, public_key, ssl, ssl_verify_fun, inets, jobs, tls_certificate_check, s3filez]],
+        Cfg = #{
+            username => <<"test-access">>,
+            password => <<"test-secret">>,
+            signature_version => v4,
+            region => <<"us-east-1">>
+        },
+        Url = list_to_binary(io_lib:format("http://127.0.0.1:~B/test-bucket/test-key-v4", [Port])),
+        ok = s3filez:put(Cfg, Url, {data, <<"hello-v4">>}),
+        {ok, <<"binary/octet-stream">>, <<"hello-v4">>} = s3filez:get(Cfg, Url),
+        ok = s3filez:delete(Cfg, Url),
+        {error, enoent} = s3filez:get(Cfg, Url)
+    after
+        stop_server(Pid)
+    end
+    end.
+
+e2e_get_missing_region_v4_test() ->
+    case start_server() of
+        {skip, Reason} ->
+            {skip, Reason};
+        {Pid, Port} ->
+            try
+                [ok = application:ensure_started(X) || X <- [crypto, public_key, ssl, ssl_verify_fun, inets, jobs, tls_certificate_check, s3filez]],
+                Cfg = #{
+                    username => <<"test-access">>,
+                    password => <<"test-secret">>,
+                    signature_version => v4
+                },
+                Url = list_to_binary(io_lib:format("http://127.0.0.1:~B/test-bucket/missing-region", [Port])),
+                {error, region_needed} = s3filez:get(Cfg, Url)
+            after
+                stop_server(Pid)
+            end
+    end.
+
+e2e_get_invalid_credentials_v4_test() ->
+    case start_server() of
+        {skip, Reason} ->
+            {skip, Reason};
+        {Pid, Port} ->
+            try
+                [ok = application:ensure_started(X) || X <- [crypto, public_key, ssl, ssl_verify_fun, inets, jobs, tls_certificate_check, s3filez]],
+                Cfg = #{
+                    username => <<"wrong-access">>,
+                    password => <<"wrong-secret">>,
+                    signature_version => v4,
+                    region => <<"us-east-1">>
+                },
+                Url = list_to_binary(io_lib:format("http://127.0.0.1:~B/test-bucket/invalid-credentials-v4", [Port])),
+                {error, forbidden} = s3filez:get(Cfg, Url)
+            after
+                stop_server(Pid)
+            end
+    end.
+
+e2e_get_invalid_credentials_v2_test() ->
+    case start_server() of
+        {skip, Reason} ->
+            {skip, Reason};
+        {Pid, Port} ->
+            try
+                [ok = application:ensure_started(X) || X <- [crypto, public_key, ssl, ssl_verify_fun, inets, jobs, tls_certificate_check, s3filez]],
+                Cfg = #{
+                    username => <<"wrong-access">>,
+                    password => <<"wrong-secret">>
+                },
+                Url = list_to_binary(io_lib:format("http://127.0.0.1:~B/test-bucket/invalid-credentials-v2", [Port])),
+                {error, forbidden} = s3filez:get(Cfg, Url)
+            after
+                stop_server(Pid)
+            end
+    end.
+
+start_server() ->
+    case gen_tcp:listen(0, [binary, {packet, raw}, {active, false}, {reuseaddr, true}]) of
+        {ok, LSock} ->
+            {ok, {_, Port}} = inet:sockname(LSock),
+            Table = ets:new(?MODULE, [set, private]),
+            Pid = spawn_link(fun() -> accept_loop(LSock, Table) end),
+            {Pid, Port};
+        {error, Reason} ->
+            {skip, {cannot_start_server, Reason}}
+    end.
+
+stop_server(Pid) ->
+    Pid ! stop,
+    ok.
+
+accept_loop(LSock, Table) ->
+    receive
+        stop ->
+            gen_tcp:close(LSock),
+            ets:delete(Table),
+            ok
+    after 0 ->
+        case gen_tcp:accept(LSock) of
+            {ok, Sock} ->
+                spawn(fun() -> handle_conn(Sock, Table) end),
+                accept_loop(LSock, Table);
+            {error, closed} ->
+                ok
+        end
+    end.
+
+handle_conn(Sock, Table) ->
+    case recv_request(Sock) of
+        {ok, Method, Path, Query, Headers, Body} ->
+            handle_request(Sock, Table, Method, Path, Query, Headers, Body);
+        _ ->
+            ok
+    end,
+    gen_tcp:close(Sock).
+
+recv_request(Sock) ->
+    case recv_until_headers(Sock, <<>>) of
+        {ok, HeaderBin, Rest} ->
+            [ReqLine | HeaderLines] = binary:split(HeaderBin, <<"\r\n">>, [global]),
+            {Method, Path, Query} = parse_request_line(ReqLine),
+            Headers = parse_headers(HeaderLines, []),
+            ContentLen = header_content_length(Headers),
+            Body = recv_body(Sock, Rest, ContentLen),
+            {ok, Method, Path, Query, Headers, Body};
+        Error ->
+            Error
+    end.
+
+recv_until_headers(Sock, Acc) ->
+    case binary:match(Acc, <<"\r\n\r\n">>) of
+        {Pos, _} ->
+            HeaderBin = binary:part(Acc, 0, Pos),
+            Rest = binary:part(Acc, Pos + 4, byte_size(Acc) - Pos - 4),
+            {ok, HeaderBin, Rest};
+        nomatch ->
+            case gen_tcp:recv(Sock, 0, ?READ_TIMEOUT) of
+                {ok, Data} ->
+                    recv_until_headers(Sock, <<Acc/binary, Data/binary>>);
+                Error ->
+                    Error
+            end
+    end.
+
+parse_request_line(Line) ->
+    [MethodBin, PathBin | _] = binary:split(Line, <<" ">>, [global]),
+    {Path, Query} =
+        case binary:split(PathBin, <<"?">>) of
+            [P, Q] -> {P, Q};
+            [P] -> {P, <<>>}
+        end,
+    {binary_to_list(MethodBin), Path, Query}.
+
+parse_headers([], Acc) ->
+    Acc;
+parse_headers([<<>> | _], Acc) ->
+    Acc;
+parse_headers([Line | Rest], Acc) ->
+    case split_header(Line) of
+        {Key, Val} ->
+            parse_headers(Rest, [{string:lowercase(binary_to_list(Key)), binary:trim(Val, leading, <<" ">>)} | Acc]);
+        error ->
+            parse_headers(Rest, Acc)
+    end.
+
+split_header(Line) ->
+    case binary:match(Line, <<":">>) of
+        {Pos, 1} ->
+            Key = binary:part(Line, 0, Pos),
+            Val = binary:part(Line, Pos + 1, byte_size(Line) - Pos - 1),
+            {Key, Val};
+        nomatch ->
+            error
+    end.
+
+header_content_length(Headers) ->
+    case lists:keyfind("content-length", 1, Headers) of
+        {_, V} -> list_to_integer(binary_to_list(V));
+        false -> 0
+    end.
+
+recv_body(_Sock, Rest, 0) ->
+    Rest;
+recv_body(Sock, Rest, Len) ->
+    Have = byte_size(Rest),
+    case Have >= Len of
+        true ->
+            binary:part(Rest, 0, Len);
+        false ->
+            case gen_tcp:recv(Sock, 0, ?READ_TIMEOUT) of
+                {ok, Data} ->
+                    recv_body(Sock, <<Rest/binary, Data/binary>>, Len);
+                _ ->
+                    Rest
+            end
+    end.
+
+handle_request(Sock, Table, Method, Path, Query, Headers, Body) ->
+    case validate_signature(Method, Path, Query, Headers, Body) of
+        ok ->
+            handle_request_ok(Sock, Table, Method, Path, Body);
+        {error, forbidden} ->
+            send_response(Sock, 403, <<"Forbidden">>, <<>>);
+        {error, bad_request} ->
+            send_response(Sock, 400, <<"Bad Request">>, <<>>)
+    end.
+
+handle_request_ok(Sock, Table, "PUT", Path, Body) ->
+    ets:insert(Table, {Path, Body}),
+    send_response(Sock, 200, <<"OK">>, <<>>);
+handle_request_ok(Sock, Table, "GET", Path, _Body) ->
+    case ets:lookup(Table, Path) of
+        [{_, Data}] ->
+            send_response(Sock, 200, <<"OK">>, Data);
+        [] ->
+            send_response(Sock, 404, <<"Not Found">>, <<>>)
+    end;
+handle_request_ok(Sock, Table, "DELETE", Path, _Body) ->
+    ets:delete(Table, Path),
+    send_response(Sock, 204, <<"No Content">>, <<>>);
+handle_request_ok(Sock, _Table, _Method, _Path, _Body) ->
+    send_response(Sock, 400, <<"Bad Request">>, <<>>).
+
+validate_signature(Method, Path, Query, Headers, Body) ->
+    case header_value("authorization", Headers) of
+        {ok, Auth} ->
+            case Auth of
+                <<"AWS4-HMAC-SHA256 ", _/binary>> ->
+                    validate_sigv4(Method, Path, Query, Headers, Body, Auth);
+                <<"AWS ", _/binary>> ->
+                    validate_sigv2(Method, Path, Headers, Body, Auth);
+                _ ->
+                    {error, bad_request}
+            end;
+        error ->
+            {error, bad_request}
+    end.
+
+validate_sigv2(Method, Path, Headers, _Body, Auth) ->
+    case parse_sigv2_auth(Auth) of
+        {ok, Access, Signature} when Access =:= <<"test-access">> ->
+            Date = header_value_or("date", Headers, <<>>),
+            ContentType = header_value_or("content-type", Headers, <<"">>),
+            ContentMD5 = header_value_or("content-md5", Headers, <<"">>),
+            Sig = s3filez_sigv2:sign(
+                #{password => <<"test-secret">>},
+                list_to_atom(string:lowercase(Method)),
+                ContentMD5,
+                ContentType,
+                Date,
+                normalize_headers(Headers),
+                <<"127.0.0.1">>,
+                Path
+            ),
+            case Signature =:= Sig of
+                true -> ok;
+                false -> {error, forbidden}
+            end;
+        _ ->
+            {error, forbidden}
+    end.
+
+validate_sigv4(Method, Path, Query, Headers, _Body, Auth) ->
+    case parse_sigv4_auth(Auth) of
+        {ok, Access, SignedHeaders, Signature} when Access =:= <<"test-access">> ->
+            case header_value("x-amz-date", Headers) of
+                {ok, AmzDate} ->
+                    PayloadHash = header_value_or("x-amz-content-sha256", Headers, <<"">>),
+                    CanonicalHeaders = signed_header_list(SignedHeaders, Headers),
+                    CanonicalRequest = iolist_to_binary([
+                        string:uppercase(Method), $\n,
+                        s3filez_sigv4:canonical_uri(Path), $\n,
+                        s3filez_sigv4:canonical_query_string(Query), $\n,
+                        element(1, s3filez_sigv4:canonical_headers(CanonicalHeaders)), $\n,
+                        SignedHeaders, $\n,
+                        PayloadHash
+                    ]),
+                    DateStamp = binary:part(AmzDate, 0, 8),
+                    StringToSign = s3filez_sigv4:string_to_sign(
+                        #{region => "us-east-1", password => <<"test-secret">>},
+                        binary_to_list(AmzDate),
+                        binary_to_list(DateStamp),
+                        CanonicalRequest
+                    ),
+                    Sig = s3filez_sigv4:signature(
+                        #{region => "us-east-1", password => <<"test-secret">>},
+                        binary_to_list(DateStamp),
+                        StringToSign
+                    ),
+                    case list_to_binary(Sig) =:= Signature of
+                        true -> ok;
+                        false -> {error, forbidden}
+                    end;
+                error ->
+                    {error, bad_request}
+            end;
+        _ ->
+            {error, forbidden}
+    end.
+
+parse_sigv2_auth(<<"AWS ", Rest/binary>>) ->
+    case binary:split(Rest, <<":">>) of
+        [Access, Sig] -> {ok, Access, Sig};
+        _ -> error
+    end;
+parse_sigv2_auth(_) ->
+    error.
+
+parse_sigv4_auth(<<"AWS4-HMAC-SHA256 ", Rest/binary>>) ->
+    Parts = binary:split(Rest, <<",">>, [global]),
+    case {find_param(<<"Credential">>, Parts), find_param(<<"SignedHeaders">>, Parts), find_param(<<"Signature">>, Parts)} of
+        {{ok, Cred}, {ok, SignedHeaders}, {ok, Sig}} ->
+            case binary:split(Cred, <<"/">>) of
+                [Access | _] -> {ok, Access, SignedHeaders, Sig};
+                _ -> error
+            end;
+        _ ->
+            error
+    end;
+parse_sigv4_auth(_) ->
+    error.
+
+find_param(Key, Parts) ->
+    Prefix = <<Key/binary, "=">>,
+    case lists:dropwhile(fun(P) -> not has_prefix(P, Prefix) end, Parts) of
+        [P | _] ->
+            {ok, binary:part(P, byte_size(Prefix), byte_size(P) - byte_size(Prefix))};
+        [] ->
+            error
+    end.
+
+has_prefix(Bin, Prefix) ->
+    case binary:match(Bin, Prefix) of
+        {0, _} -> true;
+        _ -> false
+    end.
+
+signed_header_list(SignedHeaders, Headers) ->
+    Names = binary:split(SignedHeaders, <<";">>, [global]),
+    lists:foldl(
+        fun(Name, Acc) ->
+            case header_value(binary_to_list(Name), Headers) of
+                {ok, V} -> [{binary_to_list(Name), V} | Acc];
+                error -> Acc
+            end
+        end,
+        [],
+        Names
+    ).
+
+header_value_or(Name, Headers, Default) ->
+    case header_value(Name, Headers) of
+        {ok, V} -> V;
+        error -> Default
+    end.
+
+header_value(Name, Headers) ->
+    case lists:keyfind(Name, 1, Headers) of
+        {_, V} -> {ok, V};
+        false -> error
+    end.
+
+normalize_headers(Headers) ->
+    [ {K, V} || {K, V} <- Headers ].
+
+send_response(Sock, Code, Reason, Body) ->
+    Len = byte_size(Body),
+    Resp = [
+        "HTTP/1.1 ", integer_to_list(Code), " ", binary_to_list(Reason), "\r\n",
+        "Content-Length: ", integer_to_list(Len), "\r\n",
+        "Connection: close\r\n",
+        "\r\n",
+        Body
+    ],
+    gen_tcp:send(Sock, Resp).

--- a/test/s3filez_e2e_test.erl
+++ b/test/s3filez_e2e_test.erl
@@ -32,7 +32,7 @@ e2e_put_get_delete_test() ->
             {skip, Reason};
         {Pid, Port} ->
     try
-        [ok = application:ensure_started(X) || X <- [crypto, public_key, ssl, ssl_verify_fun, inets, jobs, tls_certificate_check, s3filez]],
+        [{ok, _} = application:ensure_all_started(X) || X <- [crypto, public_key, ssl, ssl_verify_fun, inets, jobs, gproc, tls_certificate_check, s3filez]],
         Cfg = #{
             username => <<"test-access">>,
             password => <<"test-secret">>
@@ -53,7 +53,7 @@ e2e_put_get_delete_v4_test() ->
             {skip, Reason};
         {Pid, Port} ->
     try
-        [ok = application:ensure_started(X) || X <- [crypto, public_key, ssl, ssl_verify_fun, inets, jobs, tls_certificate_check, s3filez]],
+        [{ok, _} = application:ensure_all_started(X) || X <- [crypto, public_key, ssl, ssl_verify_fun, inets, jobs, gproc, tls_certificate_check, s3filez]],
         Cfg = #{
             username => <<"test-access">>,
             password => <<"test-secret">>,
@@ -76,7 +76,7 @@ e2e_get_missing_region_v4_test() ->
             {skip, Reason};
         {Pid, Port} ->
             try
-                [ok = application:ensure_started(X) || X <- [crypto, public_key, ssl, ssl_verify_fun, inets, jobs, tls_certificate_check, s3filez]],
+                [{ok, _} = application:ensure_all_started(X) || X <- [crypto, public_key, ssl, ssl_verify_fun, inets, jobs, gproc, tls_certificate_check, s3filez]],
                 Cfg = #{
                     username => <<"test-access">>,
                     password => <<"test-secret">>,
@@ -95,7 +95,7 @@ e2e_get_invalid_credentials_v4_test() ->
             {skip, Reason};
         {Pid, Port} ->
             try
-                [ok = application:ensure_started(X) || X <- [crypto, public_key, ssl, ssl_verify_fun, inets, jobs, tls_certificate_check, s3filez]],
+                [{ok, _} = application:ensure_all_started(X) || X <- [crypto, public_key, ssl, ssl_verify_fun, inets, jobs, gproc, tls_certificate_check, s3filez]],
                 Cfg = #{
                     username => <<"wrong-access">>,
                     password => <<"wrong-secret">>,
@@ -115,7 +115,7 @@ e2e_get_invalid_credentials_v2_test() ->
             {skip, Reason};
         {Pid, Port} ->
             try
-                [ok = application:ensure_started(X) || X <- [crypto, public_key, ssl, ssl_verify_fun, inets, jobs, tls_certificate_check, s3filez]],
+                [{ok, _} = application:ensure_all_started(X) || X <- [crypto, public_key, ssl, ssl_verify_fun, inets, jobs, gproc, tls_certificate_check, s3filez]],
                 Cfg = #{
                     username => <<"wrong-access">>,
                     password => <<"wrong-secret">>
@@ -131,7 +131,7 @@ start_server() ->
     case gen_tcp:listen(0, [binary, {packet, raw}, {active, false}, {reuseaddr, true}]) of
         {ok, LSock} ->
             {ok, {_, Port}} = inet:sockname(LSock),
-            Table = ets:new(?MODULE, [set, private]),
+            Table = ets:new(?MODULE, [set, public]),
             Pid = spawn_link(fun() -> accept_loop(LSock, Table) end),
             {Pid, Port};
         {error, Reason} ->
@@ -211,7 +211,7 @@ parse_headers([<<>> | _], Acc) ->
 parse_headers([Line | Rest], Acc) ->
     case split_header(Line) of
         {Key, Val} ->
-            parse_headers(Rest, [{string:lowercase(binary_to_list(Key)), binary:trim(Val, leading, <<" ">>)} | Acc]);
+            parse_headers(Rest, [{string:lowercase(binary_to_list(Key)), z_string:trim(Val)} | Acc]);
         error ->
             parse_headers(Rest, Acc)
     end.

--- a/test/s3filez_test.erl
+++ b/test/s3filez_test.erl
@@ -67,7 +67,7 @@ s3_config_adjust_url( URL ) ->
 
 s3_get( nos3 ) -> skip;
 s3_get( #{s3_bucket := B, s3_config := Cfg, s3_url := U} ) ->
-	[ok = application:ensure_started(X) || X <- [crypto, public_key, ssl, ssl_verify_fun, inets, jobs, tls_certificate_check, s3filez]],
+	[{ok, _} = application:ensure_all_started(X) || X <- [crypto, public_key, ssl, ssl_verify_fun, inets, jobs, gproc, tls_certificate_check, s3filez]],
 
 	Result = s3filez:get( Cfg, list_to_binary([U, B]) ),
 

--- a/test/s3filez_test.erl
+++ b/test/s3filez_test.erl
@@ -1,3 +1,25 @@
+%% @author Marc Worrell
+%% @copyright 2026 Marc Worrell
+%% @doc Tests for s3filez.
+%% @end
+
+%% Copyright 2026 Marc Worrell
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+
 -module(s3filez_test).
 
 -include_lib("eunit/include/eunit.hrl").

--- a/test/s3filez_test.erl
+++ b/test/s3filez_test.erl
@@ -35,25 +35,40 @@ s3_config( Secret ) ->
 	Access = os:getenv( "ERCDF_S3_ACCESS" ),
 	Bucket = os:getenv("ERCDF_S3_BUCKET" ),
 	URL = os:getenv("ERCDF_S3_URL" ),
+	Region = os:getenv("ERCDF_S3_REGION"),
+	SigVsn = os:getenv("ERCDF_S3_SIGNATURE_VERSION"),
+	Cfg0 = #{
+		username => list_to_binary(Access),
+		password => list_to_binary(Secret)
+	},
+	Cfg1 = case SigVsn of
+		"v4" -> Cfg0#{ signature_version => v4 };
+		"v2" -> Cfg0#{ signature_version => v2 };
+		_ -> Cfg0
+	end,
+	Cfg = case Region of
+		false -> Cfg1;
+		R -> Cfg1#{ region => list_to_binary(R) }
+	end,
 	#{
 		s3_bucket => s3_config_adjust_end( lists:last(Bucket), Bucket ),
-		s3_config => {binary:list_to_bin(Access), binary:list_to_bin(Secret)},
+		s3_config => Cfg,
 		s3_url => s3_config_adjust_url( URL )
 	}.
 
-s3_config_adjust_end( $/, X ) -> binary:list_to_bin( X );
-s3_config_adjust_end( _, X ) -> binary:list_to_bin( [X, <<"/">>] ).
+s3_config_adjust_end( $/, X ) -> list_to_binary( X );
+s3_config_adjust_end( _, X ) -> list_to_binary( [X, <<"/">>] ).
 
 s3_config_adjust_url( "https://"++_=URL ) ->
 	s3_config_adjust_end( lists:last(URL), URL );
 s3_config_adjust_url( URL ) ->
-	binary:list_to_bin( [<<"https://">>, s3_config_adjust_end(lists:last(URL), URL)] ).
+	list_to_binary( [<<"https://">>, s3_config_adjust_end(lists:last(URL), URL)] ).
 
 
 s3_get( nos3 ) -> skip;
-s3_get( #{s3_bucket := B, s3_config := C, s3_url := U} ) ->
+s3_get( #{s3_bucket := B, s3_config := Cfg, s3_url := U} ) ->
 	[ok = application:ensure_started(X) || X <- [crypto, public_key, ssl, ssl_verify_fun, inets, jobs, tls_certificate_check, s3filez]],
 
-	Result = s3filez:get( C, binary:list_to_bin([U, B]) ),
+	Result = s3filez:get( Cfg, list_to_binary([U, B]) ),
 
 	{ok, _Application, _Binary} =Result.

--- a/test/s3filez_v4_test.erl
+++ b/test/s3filez_v4_test.erl
@@ -1,0 +1,62 @@
+-module(s3filez_v4_test).
+
+-include_lib("eunit/include/eunit.hrl").
+
+v4_missing_region_test() ->
+    ?assertEqual({error, region_needed}, s3filez:v4_required_config(#{})),
+    ?assertEqual({error, region_needed}, s3filez:v4_required_config(#{signature_version => v4})),
+    ?assertEqual(ok, s3filez:v4_required_config(#{region => "us-east-1"})).
+
+v4_example_get_bucket_lifecycle_test() ->
+    %% Example from AWS Signature Version 4 header-based auth docs:
+    %% https://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html
+    AmzDate = "20130524T000000Z",
+    DateStamp = "20130524",
+    PayloadHash = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    Headers = [
+        {"Host", "examplebucket.s3.amazonaws.com"},
+        {"x-amz-content-sha256", PayloadHash},
+        {"x-amz-date", AmzDate}
+    ],
+    {CanonicalHeaders, SignedHeaders} = s3filez:canonical_headers(Headers),
+    CanonicalQuery = s3filez:canonical_query_string(<<"lifecycle">>),
+    CanonicalRequest = iolist_to_binary([
+        "GET\n",
+        "/\n",
+        CanonicalQuery, "\n",
+        CanonicalHeaders, "\n",
+        SignedHeaders, "\n",
+        PayloadHash
+    ]),
+    ExpectedCanonicalRequest =
+        "GET\n"
+        "/\n"
+        "lifecycle=\n"
+        "host:examplebucket.s3.amazonaws.com\n"
+        "x-amz-content-sha256:" ++ PayloadHash ++ "\n"
+        "x-amz-date:20130524T000000Z\n"
+        "\n"
+        "host;x-amz-content-sha256;x-amz-date\n"
+        ++ PayloadHash,
+    ?assertEqual(ExpectedCanonicalRequest, binary_to_list(CanonicalRequest)),
+    Config = #{
+        username => "AKIAIOSFODNN7EXAMPLE",
+        password => "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
+        region => "us-east-1"
+    },
+    StringToSign = s3filez:v4_string_to_sign(Config, AmzDate, DateStamp, CanonicalRequest),
+    ExpectedStringToSign =
+        "AWS4-HMAC-SHA256\n"
+        "20130524T000000Z\n"
+        "20130524/us-east-1/s3/aws4_request\n"
+        "9766c798316ff2757b517bc739a67f6213b4ab36dd5da2f94eaebf79c77395ca",
+    ?assertEqual(ExpectedStringToSign, binary_to_list(StringToSign)),
+    Signature = s3filez:v4_signature(Config, DateStamp, StringToSign),
+    ExpectedSignature = "964c7e476ea67fd0dbe754c179c24b69f45f4484575238740e4eef8ee26697ff",
+    ?assertEqual(ExpectedSignature, Signature),
+    Authorization = s3filez:v4_authorization(Config, DateStamp, SignedHeaders, Signature),
+    ExpectedAuth =
+        "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20130524/us-east-1/s3/aws4_request,"
+        "SignedHeaders=host;x-amz-content-sha256;x-amz-date,"
+        "Signature=" ++ ExpectedSignature,
+    ?assertEqual(ExpectedAuth, Authorization).

--- a/test/s3filez_v4_test.erl
+++ b/test/s3filez_v4_test.erl
@@ -1,11 +1,33 @@
+%% @author Marc Worrell
+%% @copyright 2013-2026 Marc Worrell
+%% @doc SigV4 unit tests for s3filez.
+%% @end
+
+%% Copyright 2013-2026 Marc Worrell
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+
 -module(s3filez_v4_test).
 
 -include_lib("eunit/include/eunit.hrl").
 
 v4_missing_region_test() ->
-    ?assertEqual({error, region_needed}, s3filez:v4_required_config(#{})),
-    ?assertEqual({error, region_needed}, s3filez:v4_required_config(#{signature_version => v4})),
-    ?assertEqual(ok, s3filez:v4_required_config(#{region => "us-east-1"})).
+    ?assertEqual({error, region_needed}, s3filez_sigv4:required_config(#{})),
+    ?assertEqual({error, region_needed}, s3filez_sigv4:required_config(#{signature_version => v4})),
+    ?assertEqual(ok, s3filez_sigv4:required_config(#{region => "us-east-1"})).
 
 v4_example_get_bucket_lifecycle_test() ->
     %% Example from AWS Signature Version 4 header-based auth docs:
@@ -18,8 +40,8 @@ v4_example_get_bucket_lifecycle_test() ->
         {"x-amz-content-sha256", PayloadHash},
         {"x-amz-date", AmzDate}
     ],
-    {CanonicalHeaders, SignedHeaders} = s3filez:canonical_headers(Headers),
-    CanonicalQuery = s3filez:canonical_query_string(<<"lifecycle">>),
+    {CanonicalHeaders, SignedHeaders} = s3filez_sigv4:canonical_headers(Headers),
+    CanonicalQuery = s3filez_sigv4:canonical_query_string(<<"lifecycle">>),
     CanonicalRequest = iolist_to_binary([
         "GET\n",
         "/\n",
@@ -44,17 +66,17 @@ v4_example_get_bucket_lifecycle_test() ->
         password => "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
         region => "us-east-1"
     },
-    StringToSign = s3filez:v4_string_to_sign(Config, AmzDate, DateStamp, CanonicalRequest),
+    StringToSign = s3filez_sigv4:string_to_sign(Config, AmzDate, DateStamp, CanonicalRequest),
     ExpectedStringToSign =
         "AWS4-HMAC-SHA256\n"
         "20130524T000000Z\n"
         "20130524/us-east-1/s3/aws4_request\n"
         "9766c798316ff2757b517bc739a67f6213b4ab36dd5da2f94eaebf79c77395ca",
     ?assertEqual(ExpectedStringToSign, binary_to_list(StringToSign)),
-    Signature = s3filez:v4_signature(Config, DateStamp, StringToSign),
+    Signature = s3filez_sigv4:signature(Config, DateStamp, StringToSign),
     ExpectedSignature = "964c7e476ea67fd0dbe754c179c24b69f45f4484575238740e4eef8ee26697ff",
     ?assertEqual(ExpectedSignature, Signature),
-    Authorization = s3filez:v4_authorization(Config, DateStamp, SignedHeaders, Signature),
+    Authorization = s3filez_sigv4:authorization(Config, DateStamp, SignedHeaders, Signature),
     ExpectedAuth =
         "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20130524/us-east-1/s3/aws4_request,"
         "SignedHeaders=host;x-amz-content-sha256;x-amz-date,"


### PR DESCRIPTION
This pull request adds support for AWS Signature Version 4 authentication to the `s3filez` Erlang S3 client, making it compatible with modern AWS S3 requirements. It introduces new configuration options, updates documentation and tests, and refactors request logic to support both signature v2 (default) and v4. Minor copyright year updates are also included.

**Signature Version 4 Support:**

* Added full implementation of AWS Signature Version 4 request signing, including canonical request creation, header normalization, query string handling, payload hashing, and signature calculation in `src/s3filez.erl`.
* Introduced new config fields (`signature_version`, `region`, `session_token`) and logic to select between v2 and v4 signing per request. [[1]](diffhunk://#diff-95083ce15c6a2244dbd3b9933f7d61da44acae52357bfd98d98e0a6c4b3d5d86R57-R78) [[2]](diffhunk://#diff-95083ce15c6a2244dbd3b9933f7d61da44acae52357bfd98d98e0a6c4b3d5d86L341-R359) [[3]](diffhunk://#diff-95083ce15c6a2244dbd3b9933f7d61da44acae52357bfd98d98e0a6c4b3d5d86L350-R376) [[4]](diffhunk://#diff-95083ce15c6a2244dbd3b9933f7d61da44acae52357bfd98d98e0a6c4b3d5d86L368-R392)

**Testing:**

* Added `test/s3filez_v4_test.erl` with EUnit tests for v4 signing, including canonical request, string-to-sign, signature, and authorization header generation.
* Updated `GNUmakefile` to run EUnit tests instead of Common Test for improved test compatibility.

**Documentation:**

* Expanded `README.md` with usage examples for both signature v2 and v4, and clarified configuration options. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L19-R20) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R45-R63) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L65)

**General Maintenance:**

* Updated copyright years to 2026 in all source files. [[1]](diffhunk://#diff-95083ce15c6a2244dbd3b9933f7d61da44acae52357bfd98d98e0a6c4b3d5d86L2-R7) [[2]](diffhunk://#diff-c3e0e5793a78096d9ea1209a68754af0c14cf21705a24e498c13b837ef10629fL7-R7) [[3]](diffhunk://#diff-26f184d37026cd752235a77d1dc3d080c7675084f3a6bed00141b6ba2621f635L2-R6) [[4]](diffhunk://#diff-7461828cc8547fd28db33ee77c3e3b3fa76540f7791f6e2d705a2cc343e2783eL2-R6) [[5]](diffhunk://#diff-3b9ddbd5945f14e36e6502cd8a1e70bf95d4546a102071dc83d89cabb1018bf6L2-R4)

These changes ensure that `s3filez` remains compatible with AWS S3 and other S3-compatible services that require Signature Version 4 authentication.